### PR TITLE
Add navigation drawer with multiple sections

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,40 +1,91 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
+      title: 'AppConstructor',
       theme: ThemeData(primarySwatch: Colors.blue),
-      home: MyHomePage(),
+      initialRoute: '/',
+      routes: {
+        '/': (context) => const HomeScreen(),
+        '/chatbot': (context) => const ChatbotScreen(),
+        '/api2': (context) => const Api2Screen(),
+        '/api3': (context) => const Api3Screen(),
+      },
     );
   }
 }
 
-class MyHomePage extends StatelessWidget {
+/// Drawer shared across all pages for navigation.
+class AppDrawer extends StatelessWidget {
+  const AppDrawer({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: ListView(
+        padding: EdgeInsets.zero,
+        children: [
+          const DrawerHeader(
+            decoration: BoxDecoration(color: Colors.blue),
+            child: Text(
+              'Secciones',
+              style: TextStyle(color: Colors.white, fontSize: 24),
+            ),
+          ),
+          ListTile(
+            leading: const Icon(Icons.home),
+            title: const Text('Home'),
+            onTap: () => Navigator.pushReplacementNamed(context, '/'),
+          ),
+          ListTile(
+            leading: const Icon(Icons.chat),
+            title: const Text('Chatbot'),
+            onTap: () => Navigator.pushReplacementNamed(context, '/chatbot'),
+          ),
+          ListTile(
+            leading: const Icon(Icons.api),
+            title: const Text('API 2'),
+            onTap: () => Navigator.pushReplacementNamed(context, '/api2'),
+          ),
+          ListTile(
+            leading: const Icon(Icons.api),
+            title: const Text('API 3'),
+            onTap: () => Navigator.pushReplacementNamed(context, '/api3'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text('AppContructor')),
+      appBar: AppBar(title: const Text('Home')),
+      drawer: const AppDrawer(),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Título encima del slice
           Padding(
             padding: const EdgeInsets.fromLTRB(18.0, 26.0, 18.0, 8.0),
-            child: Text(
+            child: const Text(
               'Test Slice de 10 Cards',
               style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
             ),
           ),
-
-          // Slice horizontal con tarjetas
           Container(
-            margin: EdgeInsets.only(bottom: 26.0),
+            margin: const EdgeInsets.only(bottom: 26.0),
             height: 200,
             child: SingleChildScrollView(
               scrollDirection: Axis.horizontal,
@@ -42,7 +93,7 @@ class MyHomePage extends StatelessWidget {
                 children: List.generate(10, (index) {
                   return Container(
                     width: 230,
-                    margin: EdgeInsets.symmetric(horizontal: 6.0),
+                    margin: const EdgeInsets.symmetric(horizontal: 6.0),
                     decoration: BoxDecoration(
                       color: Colors.grey.shade300,
                       borderRadius: BorderRadius.circular(8.0),
@@ -50,7 +101,7 @@ class MyHomePage extends StatelessWidget {
                     child: Center(
                       child: Text(
                         'Card ${index + 1}',
-                        style: TextStyle(
+                        style: const TextStyle(
                           fontSize: 16,
                           fontWeight: FontWeight.w600,
                         ),
@@ -61,11 +112,51 @@ class MyHomePage extends StatelessWidget {
               ),
             ),
           ),
-
-          // Texto centrado debajo
-          Expanded(child: Center(child: Text('Welcome to MyHomePage!'))),
+          const Expanded(
+            child: Center(child: Text('Welcome to Home!')),
+          ),
         ],
       ),
     );
   }
 }
+
+class ChatbotScreen extends StatelessWidget {
+  const ChatbotScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Chatbot')),
+      drawer: const AppDrawer(),
+      body: const Center(child: Text('Chatbot Screen')),
+    );
+  }
+}
+
+class Api2Screen extends StatelessWidget {
+  const Api2Screen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('API 2')),
+      drawer: const AppDrawer(),
+      body: const Center(child: Text('API 2 Screen')),
+    );
+  }
+}
+
+class Api3Screen extends StatelessWidget {
+  const Api3Screen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('API 3')),
+      drawer: const AppDrawer(),
+      body: const Center(child: Text('API 3 Screen')),
+    );
+  }
+}
+

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,20 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:flutter_application_1/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+  testWidgets('Navigation drawer contains all sections', (WidgetTester tester) async {
+    await tester.pumpWidget(const MyApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    // Open the drawer using the hamburger icon.
+    await tester.tap(find.byIcon(Icons.menu));
+    await tester.pumpAndSettle();
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.text('Home'), findsWidgets); // app bar + drawer item
+    expect(find.text('Chatbot'), findsOneWidget);
+    expect(find.text('API 2'), findsOneWidget);
+    expect(find.text('API 3'), findsOneWidget);
   });
 }
+


### PR DESCRIPTION
## Summary
- implement persistent top bar with hamburger to toggle a sidebar
- add routes and screens for Home, Chatbot, API 2 and API 3
- update widget tests to cover navigation drawer

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6894f43c1fa08321a4d732877d37f2d3